### PR TITLE
feat/#1 엔티티 구성

### DIFF
--- a/src/main/java/com/example/team9/Team9Application.java
+++ b/src/main/java/com/example/team9/Team9Application.java
@@ -3,7 +3,9 @@ package com.example.team9;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing // created_date, updated_date 자동 업데이트
 @SpringBootApplication(exclude = SecurityAutoConfiguration.class)
 public class Team9Application {
 

--- a/src/main/java/com/example/team9/board/domain/Board.java
+++ b/src/main/java/com/example/team9/board/domain/Board.java
@@ -1,0 +1,33 @@
+package com.example.team9.board.domain;
+
+import com.example.team9.post.domain.Post;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@NoArgsConstructor
+@Getter
+@Entity
+public class Board {
+    @Id
+    @Column(name = "board_id", nullable = false)
+    private Long boardId;
+
+    @Column(name = "board_name", nullable = false)
+    private String boardName;
+
+    @Column(name = "wrtie_grade")
+    private String writeGrade;
+
+    @Column(name = "read_grade")
+    private String readGrade;
+
+    @Column(name = "board_sort")
+    private int boardSort;
+
+    @OneToMany(mappedBy = "board")
+    private List<Post> posts;
+
+}

--- a/src/main/java/com/example/team9/comment/controller/CommentController.java
+++ b/src/main/java/com/example/team9/comment/controller/CommentController.java
@@ -1,0 +1,4 @@
+package com.example.team9.comment.controller;
+
+public class CommentController {
+}

--- a/src/main/java/com/example/team9/comment/domain/Comment.java
+++ b/src/main/java/com/example/team9/comment/domain/Comment.java
@@ -1,0 +1,35 @@
+package com.example.team9.comment.domain;
+
+import com.example.team9.commentlike.domain.CommentLike;
+import com.example.team9.member.domain.Member;
+import com.example.team9.post.domain.Post;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@NoArgsConstructor
+@Getter
+@Entity
+public class Comment {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "comment_id", nullable = false)
+    private Long commentId;
+
+    @Column(name = "comment_content", columnDefinition = "TEXT", nullable = false)
+    private String commentContent;
+
+    @ManyToOne
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    @ManyToOne
+    @JoinColumn(name = "post_id")
+    private Post post;
+
+    @OneToMany(mappedBy = "comment_id")
+    private List<CommentLike> commentLikes;
+
+}

--- a/src/main/java/com/example/team9/commentlike/domain/CommentLike.java
+++ b/src/main/java/com/example/team9/commentlike/domain/CommentLike.java
@@ -1,0 +1,26 @@
+package com.example.team9.commentlike.domain;
+
+import com.example.team9.comment.domain.Comment;
+import com.example.team9.member.domain.Member;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@Getter
+@Entity
+public class CommentLike {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "commentlike_id", nullable = false)
+    private Long commentLikeId;
+
+    @ManyToOne
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    @ManyToOne
+    @JoinColumn(name = "comment_id")
+    private Comment comment;
+}
+

--- a/src/main/java/com/example/team9/grade/domain/Grade.java
+++ b/src/main/java/com/example/team9/grade/domain/Grade.java
@@ -1,0 +1,23 @@
+package com.example.team9.grade.domain;
+
+import com.example.team9.member.domain.Member;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+
+@NoArgsConstructor
+@Getter
+@Entity
+public class Grade {
+    @Id
+    @Column(name = "grade_id", nullable = false)
+    private Long gradeId;
+
+    @Column(name = "grade_name", nullable = false)
+    private String gradeName;
+
+    @OneToOne(mappedBy = "grade")
+    private Member member;
+
+}

--- a/src/main/java/com/example/team9/member/domain/Member.java
+++ b/src/main/java/com/example/team9/member/domain/Member.java
@@ -1,5 +1,67 @@
 package com.example.team9.member.domain;
 
+import com.example.team9.grade.domain.Grade;
+import com.example.team9.post.domain.Post;
+import com.example.team9.postlike.domain.PostLike;
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@Entity
+@Table(name = "member")
 public class Member {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    // @GeneratedValue : PK 값을 각 DBMS에 맞는 자동증가 컬럼으로
+    @Column(name = "member_id", updatable = false)
+    // updatable = false : update문 처리될때 반영할건지 말건지 )
+    private Long memberId;
+
+    // member_name : 닉네임
+    @Column(name = "member_name", nullable = false, unique = true)
+    private String memberName;
+
+    // email : 아이디
+    @Column(name = "email", nullable = false, unique = true)
+    private String email;
+
+    @Column(name = "password", nullable = false)
+    private String password;
+
+    @CreatedDate
+    private LocalDateTime created_date;
+
+    @Column(name = "upgrade_request", nullable = false)
+    private boolean upgradeRequest;
+
+    // member <-> post 1:N 양방향
+    @OneToMany(mappedBy = "member")
+    private List<Post> posts;
+
+    // member <-> postLike 1:N 양? 단?
+    @OneToMany(mappedBy = "member")
+    private List<PostLike> postLikes;
+
+    //grade <-> member 1:1 양방향
+    @OneToOne
+    @JoinColumn(name = "grade_id")
+    private Grade grade;
+
+
+//    @Builder
+//    public Member(String memberName, String email, String password, String grade) {
+//        this.memberName = memberName;
+//        this.email = email;
+//        this.password = password;
+////        this.grade = grade;
+//    }
 
 }

--- a/src/main/java/com/example/team9/post/controller/PostController.java
+++ b/src/main/java/com/example/team9/post/controller/PostController.java
@@ -1,0 +1,4 @@
+package com.example.team9.post.controller;
+
+public class PostController {
+}

--- a/src/main/java/com/example/team9/post/domain/Post.java
+++ b/src/main/java/com/example/team9/post/domain/Post.java
@@ -1,0 +1,70 @@
+package com.example.team9.post.domain;
+
+import com.example.team9.board.domain.Board;
+import com.example.team9.comment.domain.Comment;
+import com.example.team9.member.domain.Member;
+import com.example.team9.postlike.domain.PostLike;
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@EntityListeners(AuditingEntityListener.class)
+@Entity
+public class Post {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "post_id", nullable = false, updatable = false)
+    private Long postId;
+
+    @Column(name = "title", nullable = false)
+    private String title;
+
+    @Column(name = "content", nullable = false, columnDefinition = "TEXT")
+    private String content;
+
+    @CreatedDate
+    @Column(name = "created_date", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(name = "updated_date")
+    private LocalDateTime updatedAt;
+
+    // 조회수
+    @Column(name = "post_view", nullable = false, columnDefinition = "BIGINT default 0")
+    private Long postView;
+
+    // 사용자 매핑
+    @ManyToOne
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    // 게시판 매핑
+    @ManyToOne
+    @JoinColumn(name = "board_id")
+    private Board board;
+
+    @OneToMany(mappedBy = "post")
+    private List<Comment> comments = new ArrayList<>();
+
+    @OneToMany(mappedBy = "post")
+    private List<PostLike> postLikes = new ArrayList<>();
+
+
+//    @Builder
+//    public Post(String title, String content, Long postView) {
+//        this.title = title;
+//        this.content = content;
+//        this.postView = postView;
+//    }
+}

--- a/src/main/java/com/example/team9/postlike/domain/PostLike.java
+++ b/src/main/java/com/example/team9/postlike/domain/PostLike.java
@@ -1,0 +1,21 @@
+package com.example.team9.postlike.domain;
+
+import com.example.team9.member.domain.Member;
+import com.example.team9.post.domain.Post;
+import jakarta.persistence.*;
+
+@Entity
+public class PostLike {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "postlike_id", nullable = false)
+    private Long postLikeId;
+
+    @ManyToOne
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    @ManyToOne
+    @JoinColumn(name = "post_id")
+    private Post post;
+}


### PR DESCRIPTION
### 🎈요약
엔티티 간단 구성


### 🗨️작업 내용
- 모든 객체 엔티티 작성

- member <-> grade (1:1 관계) 를 제외한 나머지는 N:1 관계라 생각하고 작업했습니다.

- @Column 어노테이션 속성으로 모두 name을 따로 지정하였고, null 값의 허용 여부도 설정해주었습니다.

- Application 클래스에 @EnableJpaAuditing 어노테이션 추가


### ❗참고 사항
- @Table 어노테이션 사용과 Join 매핑 부분은 좀 더 고려해서 수정해보겠습니다.


### 🔔관련 이슈 
close #1 
